### PR TITLE
Fix `SettingsState` serialization issues

### DIFF
--- a/src/main/java/org/overengineer/inlineproblems/settings/SettingsState.java
+++ b/src/main/java/org/overengineer/inlineproblems/settings/SettingsState.java
@@ -5,10 +5,12 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import com.intellij.util.xmlb.annotations.OptionTag;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.overengineer.inlineproblems.utils.ColorConverter;
 
 import java.awt.*;
 
@@ -29,18 +31,43 @@ public class SettingsState implements PersistentStateComponent<SettingsState> {
     private boolean highlightWeakWarnings = false;
     private boolean showInfos = false;
     private boolean highlightInfos = false;
+
+    @OptionTag(converter = ColorConverter.class)
     private Color errorTextColor = new Color(0xEC5151);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color errorBackgroundColor = new Color(0x654243);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color errorHighlightColor = errorBackgroundColor;
+
+    @OptionTag(converter = ColorConverter.class)
     private Color warningTextColor = new Color(0xEC821F);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color warningBackgroundColor = new Color(0x815125);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color warningHighlightColor = warningBackgroundColor;
+
+    @OptionTag(converter = ColorConverter.class)
     private Color weakWarningTextColor = new Color(0xC07937);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color weakWarningBackgroundColor = new Color(0xA47956);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color weakWarningHighlightColor = weakWarningBackgroundColor;
+
+    @OptionTag(converter = ColorConverter.class)
     private Color infoTextColor = new Color(0x3BB1CE);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color infoBackgroundColor = new Color(0x1E5664);
+
+    @OptionTag(converter = ColorConverter.class)
     private Color infoHighlightColor = infoBackgroundColor;
+
     private boolean drawBoxesAroundErrorLabels = true;
     private boolean roundedCornerBoxes = true;
     private boolean forceProblemsInSameLine = true;

--- a/src/main/java/org/overengineer/inlineproblems/settings/SettingsState.java
+++ b/src/main/java/org/overengineer/inlineproblems/settings/SettingsState.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import com.intellij.util.xmlb.annotations.OptionTag;
+import com.intellij.util.xmlb.annotations.Transient;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
@@ -33,40 +34,46 @@ public class SettingsState implements PersistentStateComponent<SettingsState> {
     private boolean highlightInfos = false;
 
     @OptionTag(converter = ColorConverter.class)
-    private Color errorTextColor = new Color(0xEC5151);
+    private Color errorTextCol = new Color(0xEC5151);
+
+    /**
+     * Rename {@code errorBackgroundColor} to {@code errorBackgroundCol} to solve
+     * the compatibility issue with old version persisted xml setting file.
+     *
+     * @see <a href="https://github.com/0verEngineer/InlineProblems/pull/10">Github discussion</a>
+     */
+    @OptionTag(converter = ColorConverter.class)
+    private Color errorBackgroundCol = new Color(0x654243);
 
     @OptionTag(converter = ColorConverter.class)
-    private Color errorBackgroundColor = new Color(0x654243);
+    private Color errorHighlightCol = errorBackgroundCol;
 
     @OptionTag(converter = ColorConverter.class)
-    private Color errorHighlightColor = errorBackgroundColor;
+    private Color warningTextCol = new Color(0xEC821F);
 
     @OptionTag(converter = ColorConverter.class)
-    private Color warningTextColor = new Color(0xEC821F);
+    private Color warningBackgroundCol = new Color(0x815125);
 
     @OptionTag(converter = ColorConverter.class)
-    private Color warningBackgroundColor = new Color(0x815125);
+    private Color warningHighlightCol = warningBackgroundCol;
 
     @OptionTag(converter = ColorConverter.class)
-    private Color warningHighlightColor = warningBackgroundColor;
+    private Color weakWarningTextCol= new Color(0xC07937);
 
     @OptionTag(converter = ColorConverter.class)
-    private Color weakWarningTextColor = new Color(0xC07937);
+    private Color weakWarningBackgroundCol = new Color(0xA47956);
 
     @OptionTag(converter = ColorConverter.class)
-    private Color weakWarningBackgroundColor = new Color(0xA47956);
+    private Color weakWarningHighlightCol = weakWarningBackgroundCol;
 
     @OptionTag(converter = ColorConverter.class)
-    private Color weakWarningHighlightColor = weakWarningBackgroundColor;
+    private Color infoTextCol = new Color(0x3BB1CE);
 
     @OptionTag(converter = ColorConverter.class)
-    private Color infoTextColor = new Color(0x3BB1CE);
+    private Color infoBackgroundCol = new Color(0x1E5664);
 
     @OptionTag(converter = ColorConverter.class)
-    private Color infoBackgroundColor = new Color(0x1E5664);
-
-    @OptionTag(converter = ColorConverter.class)
-    private Color infoHighlightColor = infoBackgroundColor;
+    private Color infoHighlightCol = infoBackgroundCol;
 
     private boolean drawBoxesAroundErrorLabels = true;
     private boolean roundedCornerBoxes = true;
@@ -89,4 +96,126 @@ public class SettingsState implements PersistentStateComponent<SettingsState> {
     public void loadState(@NotNull SettingsState state) {
         XmlSerializerUtil.copyBean(state, this);
     }
+
+    //<editor-fold desc="Handwritten Colors getter/setter to compatible with external callers.">
+    @Transient
+    public Color getErrorTextColor() {
+        return errorTextCol;
+    }
+
+    @Transient
+    public void setErrorTextColor(Color color) {
+        this.errorTextCol = color;
+    }
+
+    @Transient
+    public Color getErrorBackgroundColor() {
+        return errorBackgroundCol;
+    }
+
+    @Transient
+    public void setErrorBackgroundColor(Color color) {
+        this.errorBackgroundCol = color;
+    }
+
+    @Transient
+    public Color getErrorHighlightColor() {
+        return errorHighlightCol;
+    }
+
+    @Transient
+    public void setErrorHighlightColor(Color color) {
+        this.errorHighlightCol = color;
+    }
+
+    @Transient
+    public Color getWarningTextColor() {
+        return warningTextCol;
+    }
+
+    @Transient
+    public void setWarningTextColor(Color color) {
+        this.warningTextCol = color;
+    }
+
+    @Transient
+    public Color getWarningBackgroundColor() {
+        return warningBackgroundCol;
+    }
+
+    @Transient
+    public void setWarningBackgroundColor(Color color) {
+        this.warningBackgroundCol = color;
+    }
+
+    @Transient
+    public Color getWarningHighlightColor() {
+        return warningHighlightCol;
+    }
+
+    @Transient
+    public void setWarningHighlightColor(Color color) {
+        this.warningHighlightCol = color;
+    }
+
+    @Transient
+    public Color getWeakWarningTextColor() {
+        return weakWarningTextCol;
+    }
+
+    @Transient
+    public void setWeakWarningTextColor(Color color) {
+        this.weakWarningTextCol = color;
+    }
+
+    @Transient
+    public Color getWeakWarningBackgroundColor() {
+        return weakWarningBackgroundCol;
+    }
+
+    @Transient
+    public void setWeakWarningBackgroundColor(Color color) {
+        this.weakWarningBackgroundCol = color;
+    }
+
+    @Transient
+    public Color getWeakWarningHighlightColor() {
+        return weakWarningHighlightCol;
+    }
+
+    @Transient
+    public void setWeakWarningHighlightColor(Color color) {
+        this.weakWarningHighlightCol = color;
+    }
+
+    @Transient
+    public Color getInfoTextColor() {
+        return infoTextCol;
+    }
+
+    @Transient
+    public void setInfoTextColor(Color color) {
+        this.infoTextCol = color;
+    }
+
+    @Transient
+    public Color getInfoBackgroundColor() {
+        return infoBackgroundCol;
+    }
+
+    @Transient
+    public void setInfoBackgroundColor(Color color) {
+        this.infoBackgroundCol = color;
+    }
+
+    @Transient
+    public Color getInfoHighlightColor() {
+        return infoHighlightCol;
+    }
+
+    @Transient
+    public void setInfoHighlightColor(Color color) {
+        this.infoHighlightCol = color;
+    }
+    //</editor-fold>
 }

--- a/src/main/java/org/overengineer/inlineproblems/utils/ColorConverter.java
+++ b/src/main/java/org/overengineer/inlineproblems/utils/ColorConverter.java
@@ -1,0 +1,28 @@
+package org.overengineer.inlineproblems.utils;
+
+import com.intellij.util.xmlb.Converter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.Color;
+
+public class ColorConverter extends Converter<Color> {
+    @Nullable
+    @Override
+    public Color fromString(@NotNull String value) {
+        if (value.isEmpty() || value.isBlank()) {
+            return null;
+        }
+
+        try {
+            return Color.decode(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public @Nullable String toString(@NotNull Color value) {
+        return "#" + Integer.toHexString(value.getRGB()).substring(2);
+    }
+}


### PR DESCRIPTION
Hi,

In this PR, I've added a custom `com.intellij.util.xmlb.Converter` to deal with the `java.awt.Color`'s serialization issues: 

The `java.awt.Color#value` property is package level, which can't be involved during serialization. As show in the persistent setting file `OverEngineer_InlineProblems.xml`:

```xml
<option name="errorBackgroundColor">
      <Color />
</option>
```

This leads the custom error color settings can not be persisted.

Besides, the `java.awt.Color` does not have a no-argument constructor, deserialize with the above persisted settings during plugin startup causes an exception, which is reported in #7.

With this PR, the `java.awt.Color` would serialized into string, and the persisted setting file `OverEngineer_InlineProblems.xml` would looks like:

```xml
<application>
  <component name="org.overengineer.inlineproblems.settings.SettingsState">
    <option name="errorBackgroundColor" value="#1e4164" />
  </component>
</application>
```