### PR TITLE
Add gutter display settings in Chinese locale

### DIFF
--- a/src/main/resources/messages/SettingsBundle_zh_CN.properties
+++ b/src/main/resources/messages/SettingsBundle_zh_CN.properties
@@ -1,11 +1,15 @@
 settings.showErrors=\u663E\u793A\u9519\u8BEF
 settings.highlightErrors=\u7A81\u51FA\u663E\u793A\u9519\u8BEF
+settings.showErrorsInGutter=\u5728\u88c5\u8ba2\u533a\u57df\u663e\u793a\u9519\u8bef\u56fe\u6807
 settings.showWarnings=\u663E\u793A\u8B66\u544A
 settings.highlightWarnings=\u7A81\u51FA\u663E\u793A\u8B66\u544A
+settings.showWarningsInGutter=\u5728\u88c5\u8ba2\u533a\u57df\u663e\u793a\u8b66\u544a\u56fe\u6807
 settings.showWeakWarnings=\u663E\u793A\u8F7B\u5F31\u8B66\u544A
 settings.highlightWeakWarnings=\u7A81\u51FA\u663E\u793A\u8F7B\u5F31\u8B66\u544A
+settings.showWeakWarningsInGutter=\u5728\u88c5\u8ba2\u533a\u57df\u663e\u793a\u5f31\u8b66\u544a\u56fe\u6807
 settings.showInfos=\u663E\u793A\u4FE1\u606F
 settings.highlightInfos=\u7A81\u51FA\u663E\u793A\u4FE1\u606F
+settings.showInfosInGutter=\u5728\u88c5\u8ba2\u533a\u57df\u663e\u793a\u4fe1\u606f\u56fe\u6807
 settings.submenu.label=\u8fb9\u6846 / \u6807\u7B7E
 settings.drawBoxesAroundProblemLabels=\u5728\u95ee\u9898\u6807\u7b7e\u5468\u56f4\u7ed8\u5236\u8fb9\u6846
 settings.roundedCornerBoxes=\u5706\u89d2\u8fb9\u6846


### PR DESCRIPTION
New settings were added to the SettingsBundle_zh_CN.properties file to allow users to enable or disable the display of errors, warnings, weak warnings, and information in the gutter area of the user interface. This was made to enhance user experience and better support localization in the Chinese(text) version of the application.
![demo](https://github.com/0verEngineer/InlineProblems/assets/127063766/f443e6ab-3448-4adb-aa2b-d6a48cb25d53)

The translation of "gutter Icons" in English is based on the translation result of the official Chinese plugin for idea.
![demo1](https://github.com/0verEngineer/InlineProblems/assets/127063766/a0f57a66-8d94-4073-87ac-ea06fc9ad599)
